### PR TITLE
feat: verify Mercado Pago subscriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+firebase/functions/node_modules/

--- a/firebase/functions/index.js
+++ b/firebase/functions/index.js
@@ -1,8 +1,67 @@
 const functions = require("firebase-functions");
 const admin = require("firebase-admin");
+const axios = require("axios");
 admin.initializeApp();
 
 exports.onUserDeleted = functions.auth.user().onDelete(async (user) => {
   let firestore = admin.firestore();
   let userRef = firestore.doc("users/" + user.uid);
 });
+
+exports.verifySubscriptions = functions.pubsub
+  .schedule("every 24 hours")
+  .onRun(async (context) => {
+    const db = admin.firestore();
+    const usersSnap = await db.collection("users").get();
+    const mpToken =
+      process.env.MP_ACCESS_TOKEN ||
+      (functions.config().mercadopago || {}).access_token;
+    if (!mpToken) {
+      console.error("Mercado Pago access token not configured");
+      return null;
+    }
+    const inactiveStatuses = ["cancelled", "paused", "expired"]; // statuses that deactivate account
+    await Promise.all(
+      usersSnap.docs.map(async (userDoc) => {
+        const pagamentosSnap = await userDoc.ref
+          .collection("pagamentos")
+          .get();
+        for (const pagamentoDoc of pagamentosSnap.docs) {
+          const data = pagamentoDoc.data();
+          const mpId = data.id_mercado_pago;
+          if (!mpId) continue;
+          try {
+            const response = await axios.get(
+              `https://api.mercadopago.com/preapproval/${mpId}`,
+              {
+                headers: { Authorization: `Bearer ${mpToken}` },
+              }
+            );
+            const status = response.data.status;
+            await pagamentoDoc.ref.update({ status });
+            if (inactiveStatuses.includes(status)) {
+              await admin.auth().updateUser(userDoc.id, { disabled: true });
+              const token =
+                userDoc.get("fcmToken") || userDoc.get("fcm_token");
+              if (token) {
+                await admin.messaging().send({
+                  token,
+                  notification: {
+                    title: "Assinatura expirada",
+                    body: "Sua assinatura expirou e sua conta foi desativada.",
+                  },
+                });
+              }
+            }
+          } catch (error) {
+            console.error(
+              "Erro ao verificar assinatura para usuário",
+              userDoc.id,
+              error.message
+            );
+          }
+        }
+      })
+    );
+    return null;
+  });


### PR DESCRIPTION
## Summary
- add scheduled Cloud Function to verify Mercado Pago subscriptions and disable expired accounts
- ignore node_modules in version control

## Testing
- `npm --prefix firebase/functions test` *(fails: Missing script: "test")*
- `npm --prefix firebase/functions run lint` *(fails: ESLint couldn't find a configuration file)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fcf984a883218c4dfa885b056781